### PR TITLE
Add list DeployProjectVersions to DeployService and fix error reporting for non-200 responses

### DIFF
--- a/deploys.go
+++ b/deploys.go
@@ -79,6 +79,11 @@ type DeployVersionListResult struct {
 	Versions []*DeployVersionResult `json:"versions"`
 }
 
+func newRespErr(response *http.Response, msg string) error {
+	body := []byte{}
+	response.Body.Read(body)
+	return fmt.Errorf("%s: %s - %q", msg, response.Status, body)
+}
 
 // DeployProjectVersions will list existing versions of a deployment project
 func (d *DeployService) DeployProjectVersions(deploymentProjectID int) ([]*DeployVersionResult, error) {
@@ -99,10 +104,7 @@ func (d *DeployService) DeployProjectVersions(deploymentProjectID int) ([]*Deplo
 	}
 
 	if response.StatusCode != 200 {
-		body := []byte{}
-		response.Body.Read(body)
-		pErr := fmt.Errorf("Error getting deploy versions: %s - %q", response.Status, body)
-		return nil, pErr
+		return nil, newRespErr(response, "Error getting deploy versions")
 	}
 
 	return result.Versions, nil
@@ -130,7 +132,7 @@ func (d *DeployService) CreateDeployVersion(deploymentProjectID int, planResultK
 	}
 
 	if response.StatusCode != 200 {
-		return nil, err
+		return nil, newRespErr(response, "Error creating deploy version")
 	}
 
 	return result, nil
@@ -150,7 +152,7 @@ func (d *DeployService) ListDeploys() (DeploysResponse, error) {
 	}
 
 	if response.StatusCode != 200 {
-		return nil, err
+		return nil, newRespErr(response, "Error listing deploys")
 	}
 
 	return deployResp, nil
@@ -170,7 +172,7 @@ func (d *DeployService) DeployEnvironments(id int) (*DeployEnvironment, error) {
 	}
 
 	if response.StatusCode != 200 {
-		return nil, err
+		return nil, newRespErr(response, "Error getting environments")
 	}
 
 	return deployEnvironmentResp, nil
@@ -190,7 +192,7 @@ func (d *DeployService) DeployEnvironmentResults(id int) (*DeployEnvironmentResu
 	}
 
 	if response.StatusCode != 200 {
-		return nil, err
+		return nil, newRespErr(response, "Error getting deploy results")
 	}
 
 	return deployEnvironmentResultsResp, nil
@@ -210,7 +212,7 @@ func (d *DeployService) QueueDeploy(environmentID, versionID int) (*QueueDeployR
 	}
 
 	if response.StatusCode != 200 {
-		return nil, err
+		return nil, newRespErr(response, "Error queueing deploy")
 	}
 
 	return queueDeployRequest, nil
@@ -230,7 +232,7 @@ func (d *DeployService) DeployStatus(id int) (*DeployStatus, error) {
 	}
 
 	if response.StatusCode != 200 {
-		return nil, err
+		return nil, newRespErr(response, "Error getting deploy status")
 	}
 
 	return deployStatus, nil

--- a/deploys.go
+++ b/deploys.go
@@ -79,37 +79,6 @@ type DeployVersionListResult struct {
 	Versions []*DeployVersionResult `json:"versions"`
 }
 
-func newRespErr(response *http.Response, msg string) error {
-	body := []byte{}
-	response.Body.Read(body)
-	return fmt.Errorf("%s: %s - %q", msg, response.Status, body)
-}
-
-// DeployProjectVersions will list existing versions of a deployment project
-func (d *DeployService) DeployProjectVersions(deploymentProjectID int) ([]*DeployVersionResult, error) {
-	request, err := d.client.NewRequest(http.MethodGet, fmt.Sprintf("deploy/project/%d/versions", deploymentProjectID), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	q := request.URL.Query()
-	// Setting max-results very high to try and get all results
-	q.Set("max-results", "10000")
-	request.URL.RawQuery = q.Encode()
-
-	result := &DeployVersionListResult{}
-	response, err := d.client.Do(request, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	if response.StatusCode != 200 {
-		return nil, newRespErr(response, "Error getting deploy versions")
-	}
-
-	return result.Versions, nil
-}
-
 // CreateDeployVersion will take a deploy project id, plan result, version name and the next version name and create a release.
 func (d *DeployService) CreateDeployVersion(deploymentProjectID int, planResultKey, versionName, nextVersionName string) (*DeployVersionResult, error) {
 
@@ -131,7 +100,7 @@ func (d *DeployService) CreateDeployVersion(deploymentProjectID int, planResultK
 		return nil, err
 	}
 
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		return nil, newRespErr(response, "Error creating deploy version")
 	}
 
@@ -151,7 +120,7 @@ func (d *DeployService) ListDeploys() (DeploysResponse, error) {
 		return nil, err
 	}
 
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		return nil, newRespErr(response, "Error listing deploys")
 	}
 
@@ -171,7 +140,7 @@ func (d *DeployService) DeployEnvironments(id int) (*DeployEnvironment, error) {
 		return nil, err
 	}
 
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		return nil, newRespErr(response, "Error getting environments")
 	}
 
@@ -191,7 +160,7 @@ func (d *DeployService) DeployEnvironmentResults(id int) (*DeployEnvironmentResu
 		return nil, err
 	}
 
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		return nil, newRespErr(response, "Error getting deploy results")
 	}
 
@@ -211,7 +180,7 @@ func (d *DeployService) QueueDeploy(environmentID, versionID int) (*QueueDeployR
 		return nil, err
 	}
 
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		return nil, newRespErr(response, "Error queueing deploy")
 	}
 
@@ -231,7 +200,7 @@ func (d *DeployService) DeployStatus(id int) (*DeployStatus, error) {
 		return nil, err
 	}
 
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		return nil, newRespErr(response, "Error getting deploy status")
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,10 @@
 package bamboo
 
+import (
+	"fmt"
+	"net/http"
+)
+
 func emptyStrings(strings ...string) bool {
 	for _, s := range strings {
 		if s == "" {
@@ -7,6 +12,12 @@ func emptyStrings(strings ...string) bool {
 		}
 	}
 	return false
+}
+
+func newRespErr(response *http.Response, msg string) error {
+	body := []byte{}
+	response.Body.Read(body)
+	return fmt.Errorf("%s: %s - %q", msg, response.Status, body)
 }
 
 // Pagination used to specify the start and limit indexes of a paginated API resource


### PR DESCRIPTION
I added a simple function to list existing deployment versions, then noticed a bug in the other functions.