### PR TITLE
Twotired/testing refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 data/*
+.sw[po]
+.idea
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,8 @@ before_install:
 
 script:
   - go get -u golang.org/x/lint/golint
-  - go get golang.org/x/tools/cmd/cover
-  - go get github.com/mattn/goveralls
   - $GOPATH/bin/golint -set_exit_status .
-  - go test -v -covermode=count -coverprofile=coverage.out
-  - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - go test -v
 
 after_success:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,24 @@ language: go
 
 go:
   - "1.9.x"
+  - tip
+
+before_install:
+  - go get -t -v ./...
+
+script:
+  - go get -u golang.org/x/lint/golint
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+  - $GOPATH/bin/golint -set_exit_status .
+  - go test -v -covermode=count -coverprofile=coverage.out
+  - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+
+after_success:
+
+cache:
+  directories:
+    - $HOME/.cache/go-build
+    - $HOME/gopath/pkg/mod
+
+

--- a/clone_test.go
+++ b/clone_test.go
@@ -1,4 +1,4 @@
-package bamboo_test
+package bamboo
 
 import (
 	"encoding/json"
@@ -6,15 +6,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	bamboo "github.com/rcarmstrong/go-bamboo"
 )
 
 func TestClonePlan(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(clonePlanStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	planClone, resp, err := client.Clone.ClonePlan("CORE-TEST", "CORE-TESTS")
@@ -29,7 +27,7 @@ func TestClonePlan(t *testing.T) {
 
 func clonePlanStub(w http.ResponseWriter, r *http.Request) {
 
-	planClone := bamboo.Plan{
+	planClone := Plan{
 		Key: "CORE-TESTS",
 	}
 

--- a/comments_test.go
+++ b/comments_test.go
@@ -1,4 +1,4 @@
-package bamboo_test
+package bamboo
 
 import (
 	"encoding/json"
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	bamboo "github.com/rcarmstrong/go-bamboo"
 )
 
 var (
@@ -19,10 +17,10 @@ func TestAddComment(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(addCommentStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
-	comment := &bamboo.Comment{
+	comment := &Comment{
 		Content:   testComment,
 		ResultKey: resultCommentKey,
 	}
@@ -38,7 +36,7 @@ func TestAddComment(t *testing.T) {
 }
 
 func addCommentStub(w http.ResponseWriter, r *http.Request) {
-	comment := &bamboo.Comment{}
+	comment := &Comment{}
 	expectedURI := fmt.Sprintf("/rest/api/latest/result/%s/comment.json", resultCommentKey)
 
 	json.NewDecoder(r.Body).Decode(comment)

--- a/group_test.go
+++ b/group_test.go
@@ -1,4 +1,4 @@
-package bamboo_test
+package bamboo
 
 import (
 	"log"
@@ -6,15 +6,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	bamboo "github.com/rcarmstrong/go-bamboo"
 )
 
 func TestGroupPermissionsList(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(groupPermissionsListStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -49,7 +47,7 @@ func TestGroupPermissions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(groupPermissionsStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -84,7 +82,7 @@ func TestSetGroupPermissions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(setGroupPermissionsStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -119,7 +117,7 @@ func TestRemoveGroupPermissions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(removeGroupPermissionsStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -154,7 +152,7 @@ func TestAvailableGroupsPermissionsList(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(availableGroupsPermissionsListStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {

--- a/labels_test.go
+++ b/labels_test.go
@@ -1,4 +1,4 @@
-package bamboo_test
+package bamboo
 
 import (
 	"encoding/json"
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	bamboo "github.com/rcarmstrong/go-bamboo"
 )
 
 var (
@@ -19,10 +17,10 @@ func TestAddLabel(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(addLabelStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
-	label := &bamboo.Label{
+	label := &Label{
 		Name:      testLabel,
 		ResultKey: resultLabelKey,
 	}
@@ -38,7 +36,7 @@ func TestAddLabel(t *testing.T) {
 }
 
 func addLabelStub(w http.ResponseWriter, r *http.Request) {
-	label := &bamboo.Label{}
+	label := &Label{}
 	expectedURI := fmt.Sprintf("/rest/api/latest/result/%s/label.json", resultLabelKey)
 
 	json.NewDecoder(r.Body).Decode(label)

--- a/permissions_test.go
+++ b/permissions_test.go
@@ -1,63 +1,61 @@
-package bamboo_test
-
-import bamboo "github.com/rcarmstrong/go-bamboo"
+package bamboo
 
 var (
-	permissionsTestCases = []bamboo.PermissionsOpts{
-		bamboo.PermissionsOpts{
-			Resource: bamboo.GlobalResource,
+	permissionsTestCases = []PermissionsOpts{
+		PermissionsOpts{
+			Resource: GlobalResource,
 		},
-		bamboo.PermissionsOpts{
-			Resource: bamboo.PlanResource,
+		PermissionsOpts{
+			Resource: PlanResource,
 			Key:      "TEST",
 		},
-		bamboo.PermissionsOpts{
-			Resource: bamboo.RepositoryResource,
+		PermissionsOpts{
+			Resource: RepositoryResource,
 			Key:      "TEST",
 		},
-		bamboo.PermissionsOpts{
-			Resource: bamboo.ProjectResource,
+		PermissionsOpts{
+			Resource: ProjectResource,
 			Key:      "TEST",
 		},
-		bamboo.PermissionsOpts{
-			Resource: bamboo.EnvironmentResource,
+		PermissionsOpts{
+			Resource: EnvironmentResource,
 			Key:      "TEST",
 		},
-		bamboo.PermissionsOpts{
-			Resource: bamboo.ProjectPlanResource,
+		PermissionsOpts{
+			Resource: ProjectPlanResource,
 			Key:      "TEST",
 		},
-		bamboo.PermissionsOpts{
-			Resource: bamboo.DeploymentResource,
+		PermissionsOpts{
+			Resource: DeploymentResource,
 			Key:      "TEST",
 		},
 	}
 
 	allowedPlanAccessLevels = [][]string{
 		// Allowed to view a plan
-		[]string{bamboo.ReadPermission},
+		[]string{ReadPermission},
 		// Allowed to view and edit a plan. Cannot manually start builds.
-		[]string{bamboo.ReadPermission, bamboo.WritePermission},
+		[]string{ReadPermission, WritePermission},
 		// Allowed to view and manually build a plan. Cannot edit the plan.
-		[]string{bamboo.ReadPermission, bamboo.BuildPermission},
+		[]string{ReadPermission, BuildPermission},
 		// Allowed to view the plan and clone the plan for a new plan. Cannot edit or manually build the plan.
-		[]string{bamboo.ReadPermission, bamboo.ClonePermission},
+		[]string{ReadPermission, ClonePermission},
 		// Allowed to view, edit, and build the plan. Cannot clone the plan.
-		[]string{bamboo.ReadPermission, bamboo.WritePermission, bamboo.BuildPermission},
+		[]string{ReadPermission, WritePermission, BuildPermission},
 		// Allowed to view, edit, and clone the plan for a new plan. Cannot manually start builds.
-		[]string{bamboo.ReadPermission, bamboo.WritePermission, bamboo.ClonePermission},
+		[]string{ReadPermission, WritePermission, ClonePermission},
 		// Allowed to view, build, and clone the plan. Cannot edit the plan.
-		[]string{bamboo.ReadPermission, bamboo.BuildPermission, bamboo.ClonePermission},
+		[]string{ReadPermission, BuildPermission, ClonePermission},
 		// Allowed to view, edit, build, and clone the plan.
-		[]string{bamboo.ReadPermission, bamboo.WritePermission, bamboo.BuildPermission, bamboo.ClonePermission},
+		[]string{ReadPermission, WritePermission, BuildPermission, ClonePermission},
 		// Admin access to plan. Once admin access is granted, all other permissions are allowed and cannot be resticted.
-		[]string{bamboo.ReadPermission, bamboo.WritePermission, bamboo.BuildPermission, bamboo.ClonePermission, bamboo.AdminPermission},
+		[]string{ReadPermission, WritePermission, BuildPermission, ClonePermission, AdminPermission},
 	}
 
 	allowedProjectAccessLevels = [][]string{
 		// Allowed to create a plan in a given project
-		[]string{bamboo.CreatePermission},
+		[]string{CreatePermission},
 		// Allowed to create and administer all plans in a project
-		[]string{bamboo.CreatePermission, bamboo.AdminPermission},
+		[]string{CreatePermission, AdminPermission},
 	}
 )

--- a/result_test.go
+++ b/result_test.go
@@ -1,19 +1,17 @@
-package bamboo_test
+package bamboo
 
 import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	bamboo "github.com/rcarmstrong/go-bamboo"
 )
 
 func TestLatestResult(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(latestResultStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	_, resp, err := client.Results.LatestResult("CORE-TEST")
@@ -40,7 +38,7 @@ func TestNumberedResult(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(numberedResultStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	_, resp, err := client.Results.NumberedResult("CORE-TEST-1")

--- a/role_test.go
+++ b/role_test.go
@@ -1,4 +1,4 @@
-package bamboo_test
+package bamboo
 
 import (
 	"log"
@@ -6,15 +6,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	bamboo "github.com/rcarmstrong/go-bamboo"
 )
 
 func TestRolePermissionsList(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(rolePermissionsListStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -49,7 +47,7 @@ func TestSetLoggedInUserPermissions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(setLoggedInUserPermissionsStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -84,7 +82,7 @@ func TestRemoveLoggedInUsersPermissions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(removeLoggedInUsersPermissionsStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -119,7 +117,7 @@ func TestSetAnonymousReadPermission(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(setAnonymousReadPermissionStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -154,7 +152,7 @@ func TestRemoveAnonymousReadPermission(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(removeAnonymousReadPermissionStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {

--- a/server_test.go
+++ b/server_test.go
@@ -1,4 +1,4 @@
-package bamboo_test
+package bamboo
 
 import (
 	"encoding/json"
@@ -7,13 +7,11 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	bamboo "github.com/rcarmstrong/go-bamboo"
 )
 
-var serverState = &bamboo.TransitionStateInfo{
-	ServerInfo: bamboo.ServerInfo{
-		State:             bamboo.PausedState,
+var serverState = &TransitionStateInfo{
+	ServerInfo: ServerInfo{
+		State:             PausedState,
 		ReindexInProgress: false,
 	},
 	SetByUser: "test",
@@ -23,17 +21,17 @@ func TestStateTransitions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(transitionServerStateStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	var testCases = []struct {
 		expectedState string
-		function      func() (*bamboo.TransitionStateInfo, *http.Response, error)
+		function      func() (*TransitionStateInfo, *http.Response, error)
 	}{
-		{bamboo.PausedState, client.Server.Pause},
-		{bamboo.RunningState, client.Server.Resume},
-		{bamboo.PreparingForRestartState, client.Server.PrepareForRestart},
-		{bamboo.ReadyForRestartState, client.Server.Resume},
+		{PausedState, client.Server.Pause},
+		{RunningState, client.Server.Resume},
+		{PreparingForRestartState, client.Server.PrepareForRestart},
+		{ReadyForRestartState, client.Server.Resume},
 	}
 
 	for _, c := range testCases {
@@ -52,12 +50,12 @@ func TestReindex(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(reindexServerStateStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	var testCases = []struct {
 		expected bool
-		function func() (*bamboo.ReindexState, *http.Response, error)
+		function func() (*ReindexState, *http.Response, error)
 	}{
 		{true, client.Server.Reindex},
 		{true, client.Server.ReindexStatus},
@@ -80,15 +78,15 @@ func transitionServerStateStub(w http.ResponseWriter, r *http.Request) {
 
 	switch method {
 	case "pause":
-		serverState.State = bamboo.PausedState
+		serverState.State = PausedState
 	case "resume":
-		if serverState.State == bamboo.PausedState {
-			serverState.State = bamboo.RunningState
+		if serverState.State == PausedState {
+			serverState.State = RunningState
 		} else {
-			serverState.State = bamboo.ReadyForRestartState
+			serverState.State = ReadyForRestartState
 		}
 	case "prepareForRestart":
-		serverState.State = bamboo.PreparingForRestartState
+		serverState.State = PreparingForRestartState
 	default:
 		serverState.State = "Unknown"
 	}
@@ -102,7 +100,7 @@ func transitionServerStateStub(w http.ResponseWriter, r *http.Request) {
 }
 
 func reindexServerStateStub(w http.ResponseWriter, r *http.Request) {
-	resp := bamboo.ReindexState{
+	resp := ReindexState{
 		ReindexInProgress: true,
 		ReindexPending:    true,
 	}

--- a/user_test.go
+++ b/user_test.go
@@ -1,4 +1,4 @@
-package bamboo_test
+package bamboo
 
 import (
 	"log"
@@ -6,15 +6,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	bamboo "github.com/rcarmstrong/go-bamboo"
 )
 
 func TestUserPermissionsList(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(userPermissionsListStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -49,7 +47,7 @@ func TestUserPermissions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(userPermissionsStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -84,7 +82,7 @@ func TestSetUserPermissions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(setUserPermissionsStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -119,7 +117,7 @@ func TestRemoveUserPermissions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(removeUserPermissionsStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {
@@ -154,7 +152,7 @@ func TestAvailableUserPermissionsList(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(availableUserPermissionsListStub))
 	defer ts.Close()
 
-	client := bamboo.NewSimpleClient(nil, "", "")
+	client := NewSimpleClient(nil, "", "")
 	client.SetURL(ts.URL)
 
 	for _, tc := range permissionsTestCases {


### PR DESCRIPTION
The absolute reference in the unit tests will cause the upstream code to be downloaded and tested, even in a fork of this project. Keeping the tests in the "bamboo" pkg avoids this issue an makes it easier to contribute changes upstream.